### PR TITLE
import 'escape' from html, not from cgi

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -12,7 +12,7 @@ import time
 import statsd
 import asyncio
 
-from cgi import escape
+from html import escape
 from contextlib import contextmanager
 from datetime import datetime
 


### PR DESCRIPTION
Under python3.8 'from cgi import escape' will fail.  Import from html instead.